### PR TITLE
Fix verticalArrangement

### DIFF
--- a/verticalArrangement.gd
+++ b/verticalArrangement.gd
@@ -11,27 +11,38 @@
 
 extends ScriptRunnerScript # Do not remove this
 
-func run_script() -> int:
-	# Get selected timing points
-	var selected_timing_points := get_selected_timing_points()
-	
-	var firstPos = selected_timing_points[0].position
+# Find the earliest, highest point
+# We need this because the editor inverts get_selected_timing_points 
+# if they're selected manually (not right after using the autoarranger)???
+func find_min(arr):
+    var min_id = 0
+    for i in range(1, arr.size()):
+        var a = arr[i]
+        var b = arr[min_id]
+        if a.time != b.time:
+            min_id = min_id if b.time < a.time else i
+        else:
+            min_id = min_id if b.note_type < a.note_type else i
+    return arr[min_id]
 
-	# Iterate over them
-	for point in selected_timing_points:
-		# Check if point is a normal or slide note
-		if point is HBNoteData:
-			# What should I even do with this one pokeWHAT
-			if point.is_slide_note() or point.is_slide_hold_piece():
-				break
-		
-		# Check if point is any type of note
-		if point is HBBaseNote:
-			var newPos = point.position
-			newPos.y = firstPos.y
-			newPos.y -= -92 * point.note_type
-			set_timing_point_property(point, "position", newPos)
-	
-	# Return OK to apply the script's changes, return anything else (such as -1)
-	# to cancel it
-	return OK
+func run_script() -> int:
+    # Get selected timing points
+    var selected_timing_points := get_selected_timing_points()
+    var firstPoint = find_min(selected_timing_points)
+    
+    # Iterate over all points
+    for point in selected_timing_points:
+        # Ignore slide notes
+        if point is HBNoteData:
+            if point.is_slide_note() or point.is_slide_hold_piece():
+                continue
+
+        if point is HBBaseNote:
+            var newPos = point.position
+            newPos.y = firstPoint.position.y
+            newPos.y += 96 * (point.note_type - firstPoint.note_type)
+            set_timing_point_property(point, "position", newPos)
+
+    # Return OK to apply the script's changes, return anything else (such as -1)
+    # to cancel it
+    return OK


### PR DESCRIPTION
1. The spacing is 96 not 92 as I've been telling yall over and over.
2. get_selected_timing_points()[0] seems to give varied results so I feel safer manually choosing the reference point.
3. Your version pushes everything down if the reference point isn't a triangle. I anchor to the top point, e.g. square in a square-cross. Optimally we would have a gui with something like 4 radio buttons to choose the anchor.
4. Don't ragequit from the loop if you have found a slider
5. Hearts won't be ignored but whoever uses hearts in multinotes doesn't deserve this script